### PR TITLE
Add frontend login support

### DIFF
--- a/Classes/EventListener/ModifyLoginFormViewListener.php
+++ b/Classes/EventListener/ModifyLoginFormViewListener.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Waldhacker\Oauth2Client\EventListener;
+
+use TYPO3\CMS\FrontendLogin\Event\ModifyLoginFormViewEvent;
+use Waldhacker\Oauth2Client\Service\Oauth2ProviderManager;
+
+class ModifyLoginFormViewListener
+{
+    private Oauth2ProviderManager $oauth2ProviderManager;
+
+    public function __construct(Oauth2ProviderManager $oauth2ProviderManager)
+    {
+        $this->oauth2ProviderManager = $oauth2ProviderManager;
+    }
+
+    public function __invoke(ModifyLoginFormViewEvent $event)
+    {
+        $event->getView()->assign('providers', $this->oauth2ProviderManager->getConfiguredProviders());
+    }
+}

--- a/Classes/Events/UserLookupEvent.php
+++ b/Classes/Events/UserLookupEvent.php
@@ -27,14 +27,16 @@ final class UserLookupEvent
     private string $providerId;
     private string $code;
     private string $state;
+    private string $loginType;
 
-    public function __construct(string $providerId, ResourceOwnerInterface $resourceOwner, ?array $userRecord, string $code, string $state)
+    public function __construct(string $providerId, ResourceOwnerInterface $resourceOwner, ?array $userRecord, string $code, string $state, string $loginType)
     {
         $this->resourceOwner = $resourceOwner;
         $this->userRecord = $userRecord;
         $this->providerId = $providerId;
         $this->code = $code;
         $this->state = $state;
+        $this->loginType = $loginType;
     }
 
     /**
@@ -77,5 +79,13 @@ final class UserLookupEvent
     public function getState(): string
     {
         return $this->state;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLoginType(): string
+    {
+        return $this->loginType;
     }
 }

--- a/Classes/Form/RenderType/Oauth2ProvidersElement.php
+++ b/Classes/Form/RenderType/Oauth2ProvidersElement.php
@@ -29,7 +29,7 @@ use Waldhacker\Oauth2Client\Service\Oauth2ProviderManager;
 
 class Oauth2ProvidersElement extends AbstractFormElement
 {
-    private const TABLE = 'be_users';
+    private const TABLES = ['be_users', 'fe_users'];
     private Oauth2ProviderManager $oauth2ProviderManager;
     private UriBuilder $uriBuilder;
 
@@ -41,12 +41,12 @@ class Oauth2ProvidersElement extends AbstractFormElement
         $this->oauth2ProviderManager = GeneralUtility::makeInstance(Oauth2ProviderManager::class, $extensionConfiguration);
     }
 
-    public function render()
+    public function render(): array
     {
         $resultArray = $this->initializeResultArray();
         $tableName = $this->data['tableName'];
 
-        if ($tableName !== self::TABLE) {
+        if (!in_array($tableName, self::TABLES,true)) {
             return $resultArray;
         }
 

--- a/Classes/Repository/FrontendUserRepository.php
+++ b/Classes/Repository/FrontendUserRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the OAuth2 Client extension for TYPO3
+ * - (c) 2021 Waldhacker UG
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Waldhacker\Oauth2Client\Repository;
+
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+
+class FrontendUserRepository extends UserRepository
+{
+    public function __construct(DataHandler $dataHandler, Context $context, ConnectionPool $connectionPool)
+    {
+        parent::__construct($dataHandler, $context, $connectionPool);
+        $this->setLoginType(self::FRONTEND);
+    }
+}

--- a/Classes/Repository/UserRepository.php
+++ b/Classes/Repository/UserRepository.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the OAuth2 Client extension for TYPO3
+ * - (c) 2021 Waldhacker UG
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Waldhacker\Oauth2Client\Repository;
+
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use Waldhacker\Oauth2Client\Database\Query\Restriction\Oauth2ClientConfigBackendRestriction;
+use Waldhacker\Oauth2Client\Service\LoginService;
+
+/**
+ * If you directly instantiate this class, make sure to call `setMode()` in right after to set the operation mode.
+ * Alternatively use BackendUserRepository or FrontendUserRepository.
+ */
+class UserRepository
+{
+    public const BACKEND = 'BE';
+    public const FRONTEND = 'FE';
+
+    protected DataHandler $dataHandler;
+    protected Context $context;
+    protected ConnectionPool $connectionPool;
+    protected string $applicationType = '';
+    protected string $table = '';
+
+    public function __construct(
+        DataHandler $dataHandler,
+        Context $context,
+        ConnectionPool $connectionPool
+    ) {
+        $this->dataHandler = $dataHandler;
+        $this->context = $context;
+        $this->connectionPool = $connectionPool;
+    }
+
+    public function setLoginType(string $loginType): void
+    {
+        switch ($loginType) {
+            case self::BACKEND:
+                $this->applicationType = 'backend';
+                $this->table = 'be_users';
+                break;
+            case self::FRONTEND:
+                $this->applicationType = 'frontend';
+                $this->table = 'fe_users';
+                break;
+            default:
+                throw new \InvalidArgumentException('No such mode: ' . $loginType, 1632914797969);
+        }
+    }
+
+    /**
+     * Fetch user by provider and identifier
+     * @see LoginService
+     *
+     * @param string $provider
+     * @param string $identifier
+     * @return array|null
+     * @throws \Doctrine\DBAL\Driver\Exception
+     */
+    public function getUserByIdentity(string $provider, string $identifier): ?array
+    {
+        $qb = $this->connectionPool->getQueryBuilderForTable($this->table);
+        $qb->getRestrictions()->removeByType(Oauth2ClientConfigBackendRestriction::class);
+
+        $result = $qb->select($this->table . '.*')
+            ->from('tx_oauth2_client_configs', 'config')
+            ->join('config', $this->table, $this->table, 'config.parentid=' . $this->table . '.uid AND config.parenttable=\'' . $this->table . '\'')
+            ->where($qb->expr()->eq('identifier', $qb->createNamedParameter($identifier)))
+            ->andWhere($qb->expr()->eq('provider', $qb->createNamedParameter($provider)))
+            ->execute()
+            ->fetchAllAssociative();
+
+        return $result[0] ?? null;
+    }
+
+    public function getActiveProviders(): array
+    {
+        $qb = $this->connectionPool->getQueryBuilderForTable($this->table);
+        $userid = (int)$this->context->getPropertyFromAspect($this->applicationType . '.user', 'id');
+        $result = $qb->select('config.*')
+            ->from('tx_oauth2_client_configs', 'config')
+            ->join('config', $this->table, $this->table, 'config.parentid=' . $this->table . '.uid AND config.parenttable=\'' . $this->table . '\'')
+            ->where($qb->expr()->eq($this->table . '.uid', $qb->createNamedParameter($userid, \PDO::PARAM_INT)))
+            ->execute()
+            ->fetchAllAssociative();
+        $keys = array_column($result, 'provider');
+        return (array)array_combine($keys, $result);
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -27,3 +27,9 @@ services:
 
   Waldhacker\Oauth2Client\DataHandling\DataHandlerHook:
     public: true
+
+  Waldhacker\Oauth2Client\EventListener\ModifyLoginFormViewListener:
+    tags:
+      - name: event.listener
+        identifier: 'oauth2_client'
+        event: TYPO3\CMS\FrontendLogin\Event\ModifyLoginFormViewEvent

--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -14,7 +14,7 @@
  * The TYPO3 project - inspiring people to share!
  */
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('be_users', [
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('fe_users', [
     'tx_oauth2_client_configs' => [
         'label' => 'OAuth2 Client Configs',
         'config' => [
@@ -26,4 +26,4 @@
         ],
     ],
 ]);
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('be_users', 'tx_oauth2_client_configs', '', 'before:avatar');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('fe_users', 'tx_oauth2_client_configs', '', 'before:lastlogin');

--- a/Configuration/TCA/tx_oauth2_client_configs.php
+++ b/Configuration/TCA/tx_oauth2_client_configs.php
@@ -52,6 +52,11 @@ return [
                 'type' => 'passthrough'
             ]
         ],
+        'parenttable' => [
+            'config' => [
+                'type' => 'passthrough'
+            ]
+        ],
         'provider' => [
             'label' => 'Provider',
             'config' => [

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,0 +1,7 @@
+plugin.tx_felogin_login {
+  view {
+    templateRootPaths.2 = EXT:oauth2_client/Resources/Private/Templates/
+    partialRootPaths.2 = EXT:oauth2_client/Resources/Private/Partials/
+    layoutRootPaths.2 = EXT:oauth2_client/Resources/Private/Layouts/
+  }
+}

--- a/Resources/Private/Templates/Login/Login.html
+++ b/Resources/Private/Templates/Login/Login.html
@@ -1,0 +1,105 @@
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+    data-namespace-typo3-fluid="true">
+
+<f:flashMessages/>
+<f:if condition="{cookieWarning}">
+    <f:render partial="CookieWarning" />
+</f:if>
+
+<f:if condition="{messageKey}">
+    <h3>
+        <f:render partial="RenderLabelOrMessage" arguments="{key: '{messageKey}_header'}"/>
+    </h3>
+    <p>
+        <f:render partial="RenderLabelOrMessage" arguments="{key: '{messageKey}_message'}"/>
+    </p>
+</f:if>
+<f:if condition="{onSubmit}">
+    <f:then>
+        <f:form target="_top" fieldNamePrefix="" action="login" onsubmit="{onSubmit}">
+            <f:render section="content" arguments="{_all}"/>
+        </f:form>
+    </f:then>
+    <f:else>
+        <f:form target="_top" fieldNamePrefix="" action="login">
+            <f:render section="content" arguments="{_all}"/>
+        </f:form>
+    </f:else>
+</f:if>
+
+<f:if condition="{settings.showForgotPassword}">
+    <f:link.action action="recovery" controller="PasswordRecovery">
+        <f:render partial="RenderLabelOrMessage" arguments="{key: 'forgot_header'}"/>
+    </f:link.action>
+</f:if>
+
+<f:section name="content">
+    <fieldset>
+        <legend>
+            <f:translate key="login"/>
+        </legend>
+        <div>
+            <label>
+                <f:translate key="username"/>
+                <f:form.textfield name="user"/>
+            </label>
+        </div>
+        <div>
+            <label>
+                <f:translate key="password"/>
+                <f:form.password name="pass"/>
+            </label>
+        </div>
+
+        <f:if condition="{permaloginStatus} > -1">
+            <div>
+                <label>
+                    <f:translate id="permalogin"/>
+                    <f:if condition="{permaloginStatus} == 1">
+                        <f:then>
+                            <f:form.hidden name="permalogin" value="0" additionalAttributes="{disabled: 'disabled'}"/>
+                            <f:form.checkbox name="permalogin" id="permalogin" value="1" checked="checked"/>
+                        </f:then>
+                        <f:else>
+                            <f:form.hidden name="permalogin" value="0"/>
+                            <f:form.checkbox name="permalogin" id="permalogin" value="1"/>
+                        </f:else>
+                    </f:if>
+                </label>
+            </div>
+        </f:if>
+
+        <div>
+            <f:form.submit value="{f:translate(key: 'login')}" name="submit"/>
+            <f:if condition="{providers}">
+                <f:for each="{providers}" as="provider">
+                    <button type="submit" class="btn btn-block btn-login" name="oauth2-provider" value="{provider.identifier}">
+                        <core:icon identifier="{provider.iconIdentifier}" size="default"/> {provider.label}
+                    </button>
+                </f:for>
+            </f:if>
+        </div>
+
+        <div class="felogin-hidden">
+            <f:form.hidden name="logintype" value="login"/>
+            <f:form.hidden name="pid" value="{storagePid}"/>
+            <f:if condition="{redirectURL}!=''">
+                <f:form.hidden name="redirect_url" value="{redirectURL}" />
+            </f:if>
+            <f:if condition="{referer}!=''">
+                <f:form.hidden name="referer" value="{referer}" />
+            </f:if>
+            <f:if condition="{redirectReferrer}!=''">
+                <f:form.hidden name="redirectReferrer" value="off" />
+            </f:if>
+            <f:if condition="{noRedirect}!=''">
+                <f:form.hidden name="noredirect" value="1" />
+            </f:if>
+
+            {extraHidden}
+        </div>
+    </fieldset>
+</f:section>
+</html>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -29,7 +29,7 @@ if (file_exists(__DIR__ . '/Resources/Private/PHP/autoload.php')) {
         [
             'title' => 'OAuth2 Authentication',
             'description' => 'OAuth2 authentication for backend users',
-            'subtype' => 'getUserBE,authUserBE',
+            'subtype' => 'getUserBE,authUserBE,getUserFE,authUserFE',
             'available' => true,
             'priority' => 75,
             'quality' => 50,

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,9 +1,14 @@
 CREATE TABLE tx_oauth2_client_configs (
 	parentid   int(11)      DEFAULT '0' NOT NULL,
+	parenttable   VARCHAR(255) DEFAULT '',
 	provider   VARCHAR(255) DEFAULT '',
 	identifier VARCHAR(255) DEFAULT '',
 );
 
 CREATE TABLE be_users (
+	tx_oauth2_client_configs int(11) DEFAULT '0' NOT NULL,
+);
+
+CREATE TABLE fe_users (
 	tx_oauth2_client_configs int(11) DEFAULT '0' NOT NULL,
 );


### PR DESCRIPTION
I would like to use this extension for backend and frontend logins with Azure AD. (The Azure AD Connection configuration is done in my project extension.) The purpose of this MR is to extend the login service also for the frontend.

First I extended the `tx_oauth2_client_configs` database table by the field `parenttable` to differentiate between frontend and backend users. The TCA is therefore also extended to fill this field automatically. (Maybe an upgrade wizard is needed to fill the field in existing projects?) 

The field is also added to the fe_users TCA. To render the field for FE users I had to change the `Oauth2ProvidersElement` table check.

With the `ModifyLoginFormViewListener` the oauth2 providers are passed to the frontend login fluid template and the template is extended to render a button for each provider.

_Now comes the tricky part_ 😉

After enabling the `LoginService` for the frontend it is now necessary to handle both login types. The `BackendUserRepository` is now extending the new `UserRepository` which allows to find frontend and backend users. The callbackUrl is also different  for the frontend login plugin and therefore must be built in an other way.

The `FrontendUserRepository` is just a wrapper class which is not in use currently.

---

I don't expect this to be merged as is 😉 But maybe this can be a base to add FE-Login support the extension. I think more steps are needed: e.g.: Each Provider can be enabled optionally for FE/BE.

Feel free to contact me via Slack or Discord.