### PR TITLE
[TASK] process empty login data in authentication services

### DIFF
--- a/Classes/Authentication/BackendAuthenticationService.php
+++ b/Classes/Authentication/BackendAuthenticationService.php
@@ -208,4 +208,12 @@ class BackendAuthenticationService extends AbstractService
         }
         return $request;
     }
+
+    public function processLoginData(array &$loginData, $passwordTransmissionStrategy)
+    {
+        $loginData['uname'] = $loginData['uname'] ?? '';
+        $loginData['uident'] = $loginData['uident'] ?? '';
+
+        return true;
+    }
 }

--- a/Classes/Authentication/FrontendAuthenticationService.php
+++ b/Classes/Authentication/FrontendAuthenticationService.php
@@ -219,4 +219,12 @@ class FrontendAuthenticationService extends AbstractService
         }
         return $request;
     }
+    
+    public function processLoginData(array &$loginData, $passwordTransmissionStrategy)
+    {
+        $loginData['uname'] = $loginData['uname'] ?? '';
+        $loginData['uident'] = $loginData['uident'] ?? '';
+
+        return true;
+    }
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -14,7 +14,7 @@ if (file_exists(__DIR__ . '/Resources/Private/PHP/autoload.php')) {
         [
             'title' => 'OAuth2 Authentication',
             'description' => 'OAuth2 authentication for backend users',
-            'subtype' => 'getUserBE,authUserBE',
+            'subtype' => 'getUserBE,authUserBE,processLoginDataBE',
             'available' => true,
             'priority' => 75,
             'quality' => 50,
@@ -31,7 +31,7 @@ if (file_exists(__DIR__ . '/Resources/Private/PHP/autoload.php')) {
         [
             'title' => 'OAuth2 Authentication',
             'description' => 'OAuth2 authentication for frontend users',
-            'subtype' => 'getUserFE,authUserFE',
+            'subtype' => 'getUserFE,authUserFE,processLoginDataFE',
             'available' => true,
             'priority' => 75,
             'quality' => 50,


### PR DESCRIPTION
In TYPO3 v11 LTS with php8 the service chain crashes when passing empty loginData. This workaround overrides the functions to accept empty values.